### PR TITLE
Unmangle monitoringConfig Methods and Types

### DIFF
--- a/httputil/monitoring_config.go
+++ b/httputil/monitoring_config.go
@@ -1,6 +1,7 @@
 package httputil
 
 import "net/http"
+import "strings"
 
 // MonitoringConfig structure of data for handling configuration for
 // controlling what content is monitored.

--- a/httputil/monitoring_config.go
+++ b/httputil/monitoring_config.go
@@ -18,4 +18,21 @@ func (config *MonitoringConfig) EnsureDefaults() {
 	if len(config.Types) == 0 {
 		config.Types = []string{"text/html"}
 	}
+
+	// handle mangled/flattened monitoring config
+	if len(config.Methods) == 1 {
+		for _, configMethod := range config.Methods {
+			if strings.Contains(configMethod,"║") {
+				config.Methods = strings.Split(strings.ReplaceAll(configMethod,"║24║",""),"║")
+			}
+		}
+	}
+
+	if len(config.Types) == 1 {
+		for _, configType := range config.Types {
+			if strings.Contains(configType,"║") {
+				config.Types = strings.Split(strings.ReplaceAll(configType,"║24║",""),"║")
+			}
+		}
+	}
 }


### PR DESCRIPTION
Temporary fix/workaround for the issue of Methods and Types being flattened/mangled into a single string as described in #14